### PR TITLE
Adds imagemin and globbing for HTML files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ var browserSync     = require('browser-sync'),
     concat          = require('gulp-concat'),
     path            = require('path'),
     sass            = require('gulp-sass'),
+    imagemin        = require('gulp-imagemin'),
     inlinesource    = require('gulp-inline-source'),
     inlineCss       = require('gulp-inline-css');
 
@@ -22,6 +23,7 @@ gulp.task('serve', ['sass', 'inline'], function() {
     }
   });
 
+  gulp.watch('./src/img/*', ['images']);
   gulp.watch('./src/scss/**/*.scss', ['sass']);
   gulp.watch('./src/css/**/*.css', ['inline']);
   gulp.watch('./src/**/*.html', ['inline']);
@@ -37,7 +39,7 @@ gulp.task('sass', function () {
 });
 
 gulp.task('inline', function () {
-    gulp.src('./src/index.html')
+    gulp.src('./src/**/*.html')
         .pipe(inlinesource({
           compress: false
         }))
@@ -49,5 +51,13 @@ gulp.task('inline', function () {
         .pipe(browserSync.stream());
 });
 
+/**
+ * Images
+ */
+gulp.task('images', function () {
+  gulp.src('./src/img/*')
+    .pipe(imagemin())
+    .pipe(gulp.dest('build/img'))
+});
 
 gulp.task('default', ['serve']);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "hooters-website",
+  "name": "email-gulper",
   "version": "0.1.0",
   "licence": "UNLICENCED",
   "private": "true",
-  "description": "Hooters Website",
+  "description": "Email Gulper",
   "repository": {
     "type": "git",
-    "url": "https://github.com/themorrisonagency/hooters-website.git"
+    "url": "https://github.com/themorrisonagency/email-gulper.git"
   },
   "author": "Morrison Agency",
   "scripts": {
@@ -17,6 +17,7 @@
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",
+    "gulp-imagemin": "^3.0.3",
     "gulp-inline-css": "^3.1.0",
     "gulp-inline-source": "^3.0.0",
     "gulp-sass": "^2.3.2",


### PR DESCRIPTION
This PR includes `gulp-imagemin` for image optimization and the ability to develop emails without needing to upload images to the email service.

Also updated the `inline` task to use globbing instead of specifying `index.html`, so that if there's a campaign with more than one email using the same design, you can quickly create additional HTML files that'll be compiled as well.

Also, minor `package.json` corrections.
